### PR TITLE
change RBAC subject to serviceAccountName helper

### DIFF
--- a/charts/argocd-ecr-updater/templates/rolebinding.yaml
+++ b/charts/argocd-ecr-updater/templates/rolebinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: {{ include "argocd-ecr-updater.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "argocd-ecr-updater.fullname" . }}
+    name: {{ include "argocd-ecr-updater.serviceAccountName" . }}
 {{- end }}


### PR DESCRIPTION
This change will fix the subject Name in the RoleBinding definition so that when a custom service account name is used that will be reflected in the rolebinding as well.
This is in regards to [issue 89](https://github.com/karlderkaefer/argocd-ecr-updater/issues/89)